### PR TITLE
Feature/fp 38 일정 도메인 개발 및 회원 도메인 임시 작성

### DIFF
--- a/src/main/java/com/dbfp/footprint/api/controller/PlanController.java
+++ b/src/main/java/com/dbfp/footprint/api/controller/PlanController.java
@@ -1,0 +1,48 @@
+package com.dbfp.footprint.api.controller;
+
+import com.dbfp.footprint.api.repository.MemberRepository;
+import com.dbfp.footprint.api.request.CreatePlanRequest;
+import com.dbfp.footprint.api.response.CreatePlanResponse;
+import com.dbfp.footprint.api.service.MemberService;
+import com.dbfp.footprint.api.service.PlanService;
+import com.dbfp.footprint.domain.Member;
+import com.dbfp.footprint.domain.plan.Plan;
+import com.dbfp.footprint.dto.MemberDto;
+import com.dbfp.footprint.dto.PlanDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/plans")
+@RequiredArgsConstructor
+public class PlanController {
+
+    private final PlanService planService;
+
+
+    @PostMapping
+    public ResponseEntity<CreatePlanResponse> createPlan(@RequestBody CreatePlanRequest request, @RequestParam Long memberId) {
+        PlanDto planDto = PlanDto.convertToPlanDto(request);
+
+        PlanDto createdPlanDto = planService.createPlan(planDto, memberId);
+
+        CreatePlanResponse response = CreatePlanResponse.fromPlan(createdPlanDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @PutMapping("/{planId}")
+    public ResponseEntity<CreatePlanResponse> updatePlan(@PathVariable Long planId, @RequestBody CreatePlanRequest request) {
+        PlanDto planDto = PlanDto.convertToPlanDto(request);
+
+        PlanDto updatedPlanDto = planService.updatePlan(planId, planDto);
+        CreatePlanResponse response = CreatePlanResponse.fromPlan(updatedPlanDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{planId}")
+    public ResponseEntity<?> deletePlan(@PathVariable Long planId) {
+        planService.deletePlan(planId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/dbfp/footprint/api/repository/MemberRepository.java
+++ b/src/main/java/com/dbfp/footprint/api/repository/MemberRepository.java
@@ -1,0 +1,7 @@
+package com.dbfp.footprint.api.repository;
+
+import com.dbfp.footprint.domain.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/dbfp/footprint/api/repository/PlaceDetailsRepository.java
+++ b/src/main/java/com/dbfp/footprint/api/repository/PlaceDetailsRepository.java
@@ -1,0 +1,13 @@
+package com.dbfp.footprint.api.repository;
+
+import com.dbfp.footprint.domain.place.Place;
+import com.dbfp.footprint.domain.place.PlaceDetails;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalTime;
+import java.util.Optional;
+
+@Repository
+public interface PlaceDetailsRepository extends JpaRepository<PlaceDetails, Long> {
+}

--- a/src/main/java/com/dbfp/footprint/api/repository/PlaceRepository.java
+++ b/src/main/java/com/dbfp/footprint/api/repository/PlaceRepository.java
@@ -1,0 +1,10 @@
+package com.dbfp.footprint.api.repository;
+
+import com.dbfp.footprint.domain.place.Place;
+import com.dbfp.footprint.domain.plan.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+}

--- a/src/main/java/com/dbfp/footprint/api/repository/PlanRepository.java
+++ b/src/main/java/com/dbfp/footprint/api/repository/PlanRepository.java
@@ -1,0 +1,7 @@
+package com.dbfp.footprint.api.repository;
+
+import com.dbfp.footprint.domain.plan.Plan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+}

--- a/src/main/java/com/dbfp/footprint/api/repository/ScheduleRepository.java
+++ b/src/main/java/com/dbfp/footprint/api/repository/ScheduleRepository.java
@@ -1,0 +1,10 @@
+package com.dbfp.footprint.api.repository;
+
+import com.dbfp.footprint.domain.plan.Plan;
+import com.dbfp.footprint.domain.plan.Schedule;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ScheduleRepository extends JpaRepository<Schedule, Long> {
+}

--- a/src/main/java/com/dbfp/footprint/api/request/CreatePlaceDetailsRequest.java
+++ b/src/main/java/com/dbfp/footprint/api/request/CreatePlaceDetailsRequest.java
@@ -1,0 +1,18 @@
+package com.dbfp.footprint.api.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalTime;
+
+@Getter
+@AllArgsConstructor
+public class CreatePlaceDetailsRequest {
+
+    private String memo;
+
+    private int cost;
+
+    private LocalTime visitTime;
+
+}

--- a/src/main/java/com/dbfp/footprint/api/request/CreatePlaceRequest.java
+++ b/src/main/java/com/dbfp/footprint/api/request/CreatePlaceRequest.java
@@ -1,0 +1,24 @@
+package com.dbfp.footprint.api.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreatePlaceRequest {
+
+    private String kakaoPlaceId;
+
+    private String placeName;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private String address;
+
+    private List<CreatePlaceDetailsRequest> placeDetails;
+
+}

--- a/src/main/java/com/dbfp/footprint/api/request/CreatePlanRequest.java
+++ b/src/main/java/com/dbfp/footprint/api/request/CreatePlanRequest.java
@@ -1,0 +1,40 @@
+package com.dbfp.footprint.api.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.hibernate.validator.constraints.Length;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreatePlanRequest {
+
+    @NotBlank(message = "제목을 입력해주세요")
+    @Max(value = 45, message = "제목은 15자 이내로 입력해주세요")
+    private String title;
+
+    @NotNull(message = "여행 출발 일자를 선택해주세요")
+    private LocalDate startDate;
+
+    @NotNull(message = "여행 종료 일자를 선택해주세요")
+    private LocalDate endDate;
+
+    @NotNull(message = "여행 지역을 입력해주세요")
+    @Max(20)
+    private String region;
+
+    @NotNull
+    private boolean visible;
+
+    @NotNull
+    private boolean copyAllowed;
+
+    private List<CreateScheduleRequest> schedules;
+
+
+}

--- a/src/main/java/com/dbfp/footprint/api/request/CreateScheduleRequest.java
+++ b/src/main/java/com/dbfp/footprint/api/request/CreateScheduleRequest.java
@@ -1,0 +1,16 @@
+package com.dbfp.footprint.api.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreateScheduleRequest {
+
+    private int day;
+
+    private List<CreatePlaceRequest> places;
+
+}

--- a/src/main/java/com/dbfp/footprint/api/response/CreatePlanResponse.java
+++ b/src/main/java/com/dbfp/footprint/api/response/CreatePlanResponse.java
@@ -1,0 +1,46 @@
+package com.dbfp.footprint.api.response;
+
+import com.dbfp.footprint.dto.PlanDto;
+import com.dbfp.footprint.dto.ScheduleDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class CreatePlanResponse {
+
+    private String title;
+
+    //@DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startDate;
+
+    //@DateTimeFormat(pattern = "yyyy-MM-dd")
+    private LocalDate endDate;
+
+    private String region;
+
+    private int totalCost;
+
+    private boolean visible;
+
+    private boolean copyAllowed;
+
+    private List<ScheduleDto> schedules;
+
+
+    public static CreatePlanResponse fromPlan(PlanDto plan) {
+        return new CreatePlanResponse(
+                plan.getTitle(),
+                plan.getStartDate(),
+                plan.getEndDate(),
+                plan.getRegion(),
+                plan.getTotalCost(),
+                plan.isVisible(),
+                plan.isCopyAllowed(),
+                plan.getSchedules()
+        );
+    }
+}

--- a/src/main/java/com/dbfp/footprint/api/service/MemberService.java
+++ b/src/main/java/com/dbfp/footprint/api/service/MemberService.java
@@ -1,0 +1,16 @@
+package com.dbfp.footprint.api.service;
+
+import com.dbfp.footprint.api.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+    private final MemberRepository memberRepository;
+
+    public Long signUp() {
+        return null;
+    }
+}

--- a/src/main/java/com/dbfp/footprint/api/service/PlanService.java
+++ b/src/main/java/com/dbfp/footprint/api/service/PlanService.java
@@ -1,0 +1,147 @@
+package com.dbfp.footprint.api.service;
+
+import com.dbfp.footprint.api.repository.*;
+import com.dbfp.footprint.api.request.CreatePlanRequest;
+import com.dbfp.footprint.domain.Member;
+import com.dbfp.footprint.domain.place.Place;
+import com.dbfp.footprint.domain.place.PlaceDetails;
+import com.dbfp.footprint.domain.plan.Plan;
+import com.dbfp.footprint.domain.plan.Schedule;
+import com.dbfp.footprint.dto.PlaceDetailsDto;
+import com.dbfp.footprint.dto.PlaceDto;
+import com.dbfp.footprint.dto.PlanDto;
+import com.dbfp.footprint.dto.ScheduleDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+
+    private final PlanRepository planRepository;
+    private final ScheduleRepository scheduleRepository;
+    private final PlaceRepository placeRepository;
+    private final PlaceDetailsRepository placeDetailsRepository;
+    private final MemberRepository memberRepository;
+
+    public PlanDto createPlan(PlanDto planDto, Long memberId) {
+
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다."));
+
+        Plan plan = Plan.of(planDto, member);
+        plan = planRepository.save(plan);
+        Plan finalPlan = plan;
+        int totalCost = 0;
+
+        for (ScheduleDto scheduleDto : planDto.getSchedules()) {
+            Schedule schedule = Schedule.of(scheduleDto, finalPlan);
+            schedule = scheduleRepository.save(schedule);
+
+            for (PlaceDto placeDto : scheduleDto.getPlaces()) {
+                Place place = Place.of(placeDto, schedule);
+                place = placeRepository.save(place);
+
+                for (PlaceDetailsDto placeDetailsDto : placeDto.getPlaceDetails()) {
+                    PlaceDetails details = PlaceDetails.of(placeDetailsDto, place);
+                    placeDetailsRepository.save(details);
+
+                    totalCost += placeDetailsDto.getCost();
+                }
+            }
+        }
+
+        PlanDto resultDto = PlanDto.from(finalPlan);
+        resultDto.setTotalCost(totalCost);
+        return resultDto;
+    }
+
+    public PlanDto updatePlan(Long planId, PlanDto dto) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 여행계획입니다."));
+
+        dto.updatePlanBasicInfo(plan, dto);
+        updateSchedule(plan, dto.getSchedules());
+        planRepository.save(plan);
+
+        return PlanDto.from(plan);
+    }
+
+    public void updateSchedule(Plan plan, List<ScheduleDto> scheduleDtos) {
+
+        plan.getSchedules().removeIf(schedule ->
+                scheduleDtos.stream().noneMatch(scheduleDto -> scheduleDto.getDay() == schedule.getDay()));
+
+        for (ScheduleDto scheduleDto : scheduleDtos) {
+            Schedule schedule = plan.getSchedules().stream()
+                    .filter(s -> s.getDay() == scheduleDto.getDay())
+                    .findFirst()
+                    .orElseGet(() -> {
+                        Schedule newSchedule = new Schedule();
+                        newSchedule.setDay(scheduleDto.getDay());
+                        newSchedule.setPlan(plan);
+                        plan.getSchedules().add(newSchedule);
+
+                        return newSchedule;
+                    });
+
+            updatePlace(schedule, scheduleDto.getPlaces());
+        }
+    }
+
+    public void updatePlace(Schedule schedule, List<PlaceDto> placeDtos) {
+
+        schedule.getPlace().removeIf(place ->
+                placeDtos.stream().noneMatch(placeDto -> placeDto.getPlaceName().equals(place.getPlaceName())));
+
+        for (PlaceDto placeDto : placeDtos) {
+            Place place = schedule.getPlace().stream()
+                    .filter(p -> p.getPlaceName().equals(placeDto.getPlaceName()))
+                    .findFirst()
+                    .orElseGet(() -> {
+                        Place newPlace = new Place();
+                        newPlace.setPlaceName(placeDto.getPlaceName());
+                        newPlace.setSchedule(schedule);
+                        schedule.getPlace().add(newPlace);
+
+                        return newPlace;
+                    });
+            placeDto.updatePlaceBasicInfo(placeDto, place);
+
+            updatePlaceDetails(place, placeDto.getPlaceDetails());
+        }
+    }
+
+    public void updatePlaceDetails(Place place, List<PlaceDetailsDto> placeDetailsDtos) {
+
+        place.getPlaceDetails().removeIf(details ->
+                placeDetailsDtos.stream().noneMatch(placeDetailsDto -> placeDetailsDto.getVisitTime().equals(details.getVisitTime())));
+
+        for (PlaceDetailsDto detailsDto : placeDetailsDtos) {
+            PlaceDetails details = place.getPlaceDetails().stream()
+                    .filter(d -> d.getVisitTime().equals(detailsDto.getVisitTime()))
+                    .findFirst()
+                    .orElseGet(() -> {
+                        PlaceDetails newDetails = new PlaceDetails();
+                        newDetails.setPlace(place);
+                        place.getPlaceDetails().add(newDetails);
+
+                        return newDetails;
+                    });
+            detailsDto.updatePlaceDetailsBasicInfo(detailsDto, details);
+        }
+    }
+
+    public void deletePlan(Long planId) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 여행계획입니다."));
+
+        planRepository.delete(plan);
+    }
+
+
+
+
+}

--- a/src/main/java/com/dbfp/footprint/domain/Member.java
+++ b/src/main/java/com/dbfp/footprint/domain/Member.java
@@ -2,16 +2,19 @@ package com.dbfp.footprint.domain;
 
 import com.dbfp.footprint.domain.plan.Plan;
 import com.dbfp.footprint.domain.review.Image;
+import com.dbfp.footprint.dto.MemberDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.util.List;
 
 @Getter
+@Setter
 @Entity
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+//@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member {
 
     @Id
@@ -30,9 +33,19 @@ public class Member {
     private String kakaoId;
 
     @OneToOne
-    @JoinColumn(name = "image_id", nullable = false)
+    @JoinColumn(name = "image_id", nullable = true)
     private Image image;
 
     @OneToMany(mappedBy = "member")
     private List<Plan> plans;
+
+    public static Member of(MemberDto dto) {
+        Member member = new Member();
+        member.setNickname(dto.getNickname());
+        member.setEmail(dto.getEmail());
+        member.setPassword(dto.getPassword());
+        member.setKakaoId(dto.getKakaoId());
+
+        return member;
+    }
 }

--- a/src/main/java/com/dbfp/footprint/domain/place/Place.java
+++ b/src/main/java/com/dbfp/footprint/domain/place/Place.java
@@ -1,14 +1,19 @@
 package com.dbfp.footprint.domain.place;
 
 import com.dbfp.footprint.domain.plan.Schedule;
+import com.dbfp.footprint.dto.PlaceDto;
+import com.dbfp.footprint.dto.ScheduleDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @Table(name = "place")
 public class Place {
@@ -34,7 +39,20 @@ public class Place {
 
     private String address;
 
-    @OneToMany(mappedBy = "place")
-    private List<PlaceDetails> placeDetails;
+    @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<PlaceDetails> placeDetails = new ArrayList<>();
+
+    public static Place of(PlaceDto dto, Schedule schedule) {
+        Place place = new Place();
+        schedule.getPlace().add(place);
+        place.setSchedule(schedule);
+        place.setKakaoPlaceId(dto.getKakaoPlaceId());
+        place.setPlaceName(dto.getPlaceName());
+        place.setLatitude(dto.getLatitude());
+        place.setLongitude(dto.getLongitude());
+        place.setAddress(dto.getAddress());
+
+        return place;
+    }
 
 }

--- a/src/main/java/com/dbfp/footprint/domain/place/PlaceDetails.java
+++ b/src/main/java/com/dbfp/footprint/domain/place/PlaceDetails.java
@@ -1,13 +1,16 @@
 package com.dbfp.footprint.domain.place;
 
+import com.dbfp.footprint.dto.PlaceDetailsDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-import java.sql.Time;
+import java.time.LocalTime;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor
 @Table(name = "place_details")
 public class PlaceDetails {
@@ -26,5 +29,16 @@ public class PlaceDetails {
     private int cost;
 
     @Column(nullable = false)
-    private Time visitTime;
+    private LocalTime visitTime;
+
+    public static PlaceDetails of(PlaceDetailsDto dto, Place place) {
+        PlaceDetails details = new PlaceDetails();
+        place.getPlaceDetails().add(details);
+        details.setPlace(place);
+        details.setMemo(dto.getMemo());
+        details.setCost(dto.getCost());
+        details.setVisitTime(dto.getVisitTime());
+
+        return details;
+    }
 }

--- a/src/main/java/com/dbfp/footprint/domain/plan/Plan.java
+++ b/src/main/java/com/dbfp/footprint/domain/plan/Plan.java
@@ -1,15 +1,19 @@
 package com.dbfp.footprint.domain.plan;
 
 import com.dbfp.footprint.domain.Member;
+import com.dbfp.footprint.dto.PlanDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
-import java.util.Date;
+import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
+@Setter
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Plan {
@@ -25,13 +29,11 @@ public class Plan {
     @Column(length = 50, nullable = false)
     private String title;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(nullable = false)
-    private Date startDate;
+    private LocalDate startDate;
 
-    @Temporal(TemporalType.TIMESTAMP)
     @Column(nullable = false)
-    private Date endDate;
+    private LocalDate endDate;
 
     @Column(nullable = false)
     private String region;
@@ -42,7 +44,20 @@ public class Plan {
     @Column(nullable = false)
     private boolean copyAllowed;
 
-    @OneToMany(mappedBy = "plan")
-    private List<Schedule> schedules;
+    @OneToMany(mappedBy = "plan", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Schedule> schedules = new ArrayList<>();
+
+    public static Plan of(PlanDto dto, Member member) {
+        Plan plan = new Plan();
+        plan.setMember(member);
+        plan.setTitle(dto.getTitle());
+        plan.setStartDate(dto.getStartDate());
+        plan.setEndDate(dto.getEndDate());
+        plan.setRegion(dto.getRegion());
+        plan.setVisible(dto.isVisible());
+        plan.setCopyAllowed(dto.isCopyAllowed());
+
+        return plan;
+    }
 
 }

--- a/src/main/java/com/dbfp/footprint/domain/plan/Schedule.java
+++ b/src/main/java/com/dbfp/footprint/domain/plan/Schedule.java
@@ -1,16 +1,19 @@
 package com.dbfp.footprint.domain.plan;
 
 import com.dbfp.footprint.domain.place.Place;
+import com.dbfp.footprint.dto.ScheduleDto;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
 @Getter
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter
 public class Schedule {
 
     @Id
@@ -24,6 +27,15 @@ public class Schedule {
     @Column(nullable = false)
     private int day;
 
-    @OneToMany(mappedBy = "schedule")
-    private List<Place> place;
+    @OneToMany(mappedBy = "schedule", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Place> place = new ArrayList<>();
+
+    public static Schedule of(ScheduleDto dto, Plan plan) {
+        Schedule schedule = new Schedule();
+        plan.getSchedules().add(schedule); // 추가
+        schedule.setPlan(plan);
+        schedule.setDay(dto.getDay());
+
+        return schedule;
+    }
 }

--- a/src/main/java/com/dbfp/footprint/dto/MemberDto.java
+++ b/src/main/java/com/dbfp/footprint/dto/MemberDto.java
@@ -1,0 +1,19 @@
+package com.dbfp.footprint.dto;
+
+import jakarta.persistence.Column;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class MemberDto {
+
+    private String nickname;
+
+    private String email;
+
+    private String password;
+
+    private String kakaoId;
+
+}

--- a/src/main/java/com/dbfp/footprint/dto/PlaceDetailsDto.java
+++ b/src/main/java/com/dbfp/footprint/dto/PlaceDetailsDto.java
@@ -1,0 +1,36 @@
+package com.dbfp.footprint.dto;
+
+import com.dbfp.footprint.domain.place.PlaceDetails;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalTime;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PlaceDetailsDto {
+
+    private String memo;
+
+    private int cost;
+
+    @NotNull
+    private LocalTime visitTime;
+
+    public static PlaceDetailsDto from(PlaceDetails entity) {
+        return new PlaceDetailsDto(
+                entity.getMemo(),
+                entity.getCost(),
+                entity.getVisitTime()
+        );
+    }
+
+    public void updatePlaceDetailsBasicInfo(PlaceDetailsDto placeDetailsDto, PlaceDetails details) {
+        details.setMemo(placeDetailsDto.getMemo());
+        details.setCost(placeDetailsDto.getCost());
+        details.setVisitTime(placeDetailsDto.getVisitTime());
+    }
+}

--- a/src/main/java/com/dbfp/footprint/dto/PlaceDto.java
+++ b/src/main/java/com/dbfp/footprint/dto/PlaceDto.java
@@ -1,0 +1,51 @@
+package com.dbfp.footprint.dto;
+
+import com.dbfp.footprint.domain.place.Place;
+import com.dbfp.footprint.domain.plan.Plan;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class PlaceDto {
+
+    @NotNull
+    private String kakaoPlaceId;
+
+    @NotNull
+    private String placeName;
+
+    private Double latitude;
+
+    private Double longitude;
+
+    private String address;
+
+    private List<PlaceDetailsDto> placeDetails;
+
+    public static PlaceDto from(Place entity) {
+        return new PlaceDto(
+                entity.getKakaoPlaceId(),
+                entity.getPlaceName(),
+                entity.getLatitude(),
+                entity.getLongitude(),
+                entity.getAddress(),
+                entity.getPlaceDetails().stream()
+                        .map(PlaceDetailsDto::from)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public void updatePlaceBasicInfo(PlaceDto placeDto, Place place) {
+        place.setLatitude(placeDto.getLatitude());
+        place.setLongitude(placeDto.getLongitude());
+        place.setAddress(placeDto.getAddress());
+        place.setKakaoPlaceId(placeDto.getKakaoPlaceId());
+    }
+}

--- a/src/main/java/com/dbfp/footprint/dto/PlanDto.java
+++ b/src/main/java/com/dbfp/footprint/dto/PlanDto.java
@@ -1,0 +1,109 @@
+package com.dbfp.footprint.dto;
+
+import com.dbfp.footprint.api.request.CreatePlanRequest;
+import com.dbfp.footprint.domain.plan.Plan;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+//@AllArgsConstructor
+public class PlanDto {
+
+    private String title;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    private String region;
+
+    private boolean visible;
+
+    private boolean copyAllowed;
+
+    private List<ScheduleDto> schedules;
+
+    @Setter
+    private int totalCost;
+
+    public PlanDto(String title, LocalDate startDate, LocalDate endDate, String region, boolean visible, boolean copyAllowed, List<ScheduleDto> schedules) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.region = region;
+        this.visible = visible;
+        this.copyAllowed = copyAllowed;
+        this.schedules = schedules;
+        this.totalCost = 0;
+    }
+
+    public static PlanDto from(Plan entity) {
+        return new PlanDto(
+                entity.getTitle(),
+                entity.getStartDate(),
+                entity.getEndDate(),
+                entity.getRegion(),
+                entity.isVisible(),
+                entity.isCopyAllowed(),
+                entity.getSchedules().stream()
+                        .map(ScheduleDto::from)
+                        .collect(Collectors.toList())
+        );
+    }
+
+    public static PlanDto convertToPlanDto(CreatePlanRequest request) {
+        // 세부 일정(Schedule) 변환
+        List<ScheduleDto> scheduleDtos = request.getSchedules().stream().map(scheduleRequest -> {
+            // 장소(Place) 변환
+            List<PlaceDto> placeDtos = scheduleRequest.getPlaces().stream().map(placeRequest -> {
+                // 장소 세부정보(PlaceDetails) 변환
+                List<PlaceDetailsDto> placeDetailsDtos = placeRequest.getPlaceDetails().stream().map(detailsRequest ->
+                        new PlaceDetailsDto(
+                                detailsRequest.getMemo(),
+                                detailsRequest.getCost(),
+                                detailsRequest.getVisitTime()
+                        )
+                ).collect(Collectors.toList());
+
+                return new PlaceDto(
+                        placeRequest.getKakaoPlaceId(),
+                        placeRequest.getPlaceName(),
+                        placeRequest.getLatitude(),
+                        placeRequest.getLongitude(),
+                        placeRequest.getAddress(),
+                        placeDetailsDtos
+                );
+            }).collect(Collectors.toList());
+
+            return new ScheduleDto(
+                    scheduleRequest.getDay(),
+                    placeDtos
+            );
+        }).collect(Collectors.toList());
+
+        return new PlanDto(
+                request.getTitle(),
+                request.getStartDate(),
+                request.getEndDate(),
+                request.getRegion(),
+                request.isVisible(),
+                request.isCopyAllowed(),
+                scheduleDtos
+        );
+    }
+
+    public void updatePlanBasicInfo(Plan plan, PlanDto dto) {
+        plan.setTitle(dto.getTitle());
+        plan.setStartDate(dto.getStartDate());
+        plan.setEndDate(dto.getEndDate());
+        plan.setRegion(dto.getRegion());
+        plan.setVisible(dto.isVisible());
+        plan.setCopyAllowed(dto.isCopyAllowed());
+    }
+}

--- a/src/main/java/com/dbfp/footprint/dto/ScheduleDto.java
+++ b/src/main/java/com/dbfp/footprint/dto/ScheduleDto.java
@@ -1,0 +1,32 @@
+package com.dbfp.footprint.dto;
+
+import com.dbfp.footprint.domain.place.Place;
+import com.dbfp.footprint.domain.plan.Plan;
+import com.dbfp.footprint.domain.plan.Schedule;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class ScheduleDto {
+
+    @NotNull
+    private int day;
+
+    private List<PlaceDto> places;
+
+    public static ScheduleDto from(Schedule entity) {
+        return new ScheduleDto(
+                entity.getDay(),
+                entity.getPlace().stream()
+                        .map(PlaceDto::from)
+                        .collect(Collectors.toList())
+        );
+    }
+}


### PR DESCRIPTION
일정 추가, 수정, 삭제 개발 완료했습니다

새로 추가 된 부분
- PlanController, PlanService
- Plan, Schedule, Place, PlaceDetails Repository, request, dto
- CreatePlanResponse
- 회원 Repository, Service, MemberDto (임시작성)

일부 수정 된 부분
- Plan 엔티티 내 startDate와 endDate 필드 타입 Date -> LocalDate 변경
- PlaceDetails 엔티티 내 visitTime 필드 타입을 Time -> LocalTime 변경
- Plan, Schedule, Place, PlaceDeatils 엔티티 내 of 메서드 추가, cascade 속성 추가 및 배열 초기화

참고
```
@PostMapping
    public ResponseEntity<CreatePlanResponse> createPlan(@RequestBody CreatePlanRequest request, @RequestParam Long memberId) {
        PlanDto planDto = PlanDto.convertToPlanDto(request);

        PlanDto createdPlanDto = planService.createPlan(planDto, memberId);

        CreatePlanResponse response = CreatePlanResponse.fromPlan(createdPlanDto);
        return ResponseEntity.ok(response);
    }
```
위의 코드에서 회원 고유번호를 임시로 받기위해 @RequestParam을 사용하였는데 추후에 회원 개발하면서 수정해야 함